### PR TITLE
Added Applicative, Alternative, and Monad instances. Also mapGroupKeysWith

### DIFF
--- a/src/Data/Multimap/Collection.hs
+++ b/src/Data/Multimap/Collection.hs
@@ -6,10 +6,11 @@ module Data.Multimap.Collection (
   Collection(..)
 ) where
 
-import Prelude hiding (filter)
+import Prelude hiding (filter, null)
 import qualified Prelude as Prelude
 
 import Data.Foldable (foldl')
+import Data.Monoid (Alt(Alt, getAlt))
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Data.Set (Set)
@@ -49,3 +50,9 @@ instance Collection Set where
   filter = Set.filter
   size = Set.size
   null = Set.null
+
+instance Collection c => Collection (Alt c) where
+  singleton = Alt . singleton
+  filter f = Alt . filter f . getAlt
+  size = size . getAlt
+  null = null . getAlt

--- a/test/Spec/Multimap.hs
+++ b/test/Spec/Multimap.hs
@@ -11,6 +11,7 @@ import Data.Char (toUpper)
 import qualified Data.List as List
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Semigroup (Sum(Sum))
 import Data.Set (Set)
 import qualified Data.Set as Set
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -46,6 +47,11 @@ listMultimapSpec = describe "ListMultimap" $ do
     minViewWith List.uncons m `shouldBe` Just ((1, 'a'), fromGroupList [(1, "b"), (2, "c")])
     maxViewWith List.uncons m `shouldBe` Just ((2, 'c'), fromGroupList [(1, "ab")])
     maxViewWith List.uncons (empty :: ListMultimap Int Char) `shouldBe` Nothing
+  it "is a monad" $
+    (do a <- fromGroupList [(Sum 1, "abc"), (Sum 2, "")]
+        fromGroupList [(Sum 3, [toUpper a, a]), (Sum 5, a : "def")])
+    `shouldBe`
+    fromGroupList [(Sum 4, "AaBbCc"), (Sum 6, "adefbdefcdef")]
 
 seqMultimapSpec :: Spec
 seqMultimapSpec = describe "SeqMultimap" $ do


### PR DESCRIPTION
Here's an informal proof of the first two monad laws for `ListMultiMap`:

return a >>= f
singleton mempty a >>= f
Multimap (singleton mempty [a]) >>= f
unalt (joinMultimap (foldMap (alt . f) <$> singleton mempty [a]))
unalt (joinMultimap (singleton mempty (foldMap (alt . f) [a])))
unalt (joinMultimap (singleton mempty (alt (f a))))
unalt (Map.foldMapWithKey (mapGroupKeysWith (<>) . (<>)) (singleton mempty (alt (f a))))
unalt ((mapGroupKeysWith (<>) . (<>)) mempty (alt (f a)))
unalt (mapGroupKeysWith (<>) (mempty <>) (alt (f a)))
unalt (mapGroupKeysWith (<>) id (alt (f a)))
unalt (alt (f a))
f a

Multimap m >>= return
unalt $ joinMultimap (foldMap (alt . return) <$> m)
unalt $ joinMultimap (foldMap (alt . singleton mempty) <$> m)
unalt $ joinMultimap (foldMap (singleton mempty . Alt) <$> m)
unalt $ (Map.foldMapWithKey (\k ca-> mapGroupKeysWith (<>) (k <>) ca)) (foldMap (singleton mempty . Alt) <$> m)
unalt $ Map.foldMapWithKey (\k ca-> mapGroupKeysWith (<>) (k <>) (singleton mempty $ Alt ca)) m
unalt $ Map.foldMapWithKey (\k ca-> singleton k $ Alt ca) m
unalt $ Multimap (Alt <$> m)
m

The third law would be rather more difficult to prove, but I'm pretty confident it holds.
join . fmap join = join . join
